### PR TITLE
Notify admin if a content blocker affects settings form

### DIFF
--- a/js/settings/admin.js
+++ b/js/settings/admin.js
@@ -1,6 +1,8 @@
 /* global OCP, OC */
 
 $(function() {
+   $('#piwikAdblockerWarning').hide();
+
    function showRequestResult(element, result) {
       if (element.attr('type') === 'checkbox') {
          element = $('label[for="' + element.attr('id') + '"]');

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -6,6 +6,7 @@ style('piwik', 'settings');
 <div id="piwikSettings" class="section">
 	<h2>Piwik/Matomo Tracking</h2>
 	<p class="settings-hint">If you have no Piwik/Matomo instance, go to <a href="https://matomo.org" target="_blank">matomo.org</a> for further instructions.</p>
+	<p id="piwikAdblockerWarning" style="border-left:2px red solid;padding-left:1em">It seems that you use a content blocker plugin in your browser to stop trackers like Matomo. Unfortunately, your plugin also breaks this settings form, so you might want to disable the content blocker for your NextCloud.</p>
 
 	<form>
 		<table>


### PR DESCRIPTION
Some content blockers for browsers filter HTML resources by certain keywords in their URLs, for example `piwik` or `matomo`. This prevents loading of JavaScript and CSS required for the settings form of the piwik/matomo plugin.

This PR adds a little text above the settings form to notify NextCloud admins about content blockers. If JavaScript is not blocked by any rule, the text hint disappears automatically.

Fixes #53.