### PR TITLE
Fix missing CSP exception in NC16

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -12,10 +12,10 @@ if (!empty($url)) {
 
     $parseurl = parse_url($url);
     $url = isset($parseurl['host']) ? $parseurl['host'] : gethostname();
-    $url .= isset($parseurl['path']) ? $parseurl['path'] : '';
     if (isset($parseurl['port'])) {
       $url .= ':' . (string) $parseurl['port'];
     }
+    $url .= isset($parseurl['path']) ? $parseurl['path'] : '';
     $policy = new OCP\AppFramework\Http\ContentSecurityPolicy();
 
     if ($url !== false && array_key_exists('HTTP_HOST', $_SERVER)

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -15,7 +15,7 @@ if (!empty($url)) {
     if (isset($parseurl['port'])) {
       $url .= ':' . (string) $parseurl['port'];
     }
-    $url .= isset($parseurl['path']) ? $parseurl['path'] : '';
+    $url .= '/';
     $policy = new OCP\AppFramework\Http\ContentSecurityPolicy();
 
     if ($url !== false && array_key_exists('HTTP_HOST', $_SERVER)

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -11,7 +11,8 @@ if (!empty($url)) {
     );
 
     $parseurl = parse_url($url);
-    $url = (isset($parseurl['host'])) ? $parseurl['host'] : false;
+    $url = isset($parseurl['host']) ? $parseurl['host'] : gethostname();
+    $url .= isset($parseurl['path']) ? $parseurl['path'] : '';
     if (isset($parseurl['port'])) {
       $url .= ':' . (string) $parseurl['port'];
     }


### PR DESCRIPTION
The CSP exception URL requires host and path.
`host` is either given by settings or by `gethostname()` and ~~`path` only from settings~~ a `/`